### PR TITLE
Update __init__.py

### DIFF
--- a/build/lib/contrastive/__init__.py
+++ b/build/lib/contrastive/__init__.py
@@ -296,6 +296,10 @@ class CPCA(object):
         eig_idx = eig_idx[np.argsort(-w[eig_idx])]
         v_top = v[:,eig_idx]
         reduced_dataset = dataset.dot(v_top)
+        
+        if type(reduced_dataset) == type(pd.DataFrame()):
+            reduced_dataset = reduced_dataset.to_numpy()
+            
         reduced_dataset[:,0] = reduced_dataset[:,0]*np.sign(reduced_dataset[0,0])
         reduced_dataset[:,1] = reduced_dataset[:,1]*np.sign(reduced_dataset[0,1])
         return reduced_dataset


### PR DESCRIPTION
Updated function cpca_alpha - was giving error if the parameter "dataset" passed to it was pandas dataframe, because the slicing method used was deprecated in pandas.

Fixed error by converting pandas dataframes to numpy arrays.